### PR TITLE
Adding geometry for load application and fixes in testing for model

### DIFF
--- a/stem/load.py
+++ b/stem/load.py
@@ -24,8 +24,8 @@ class PointLoad(LoadParametersABC):
         - value (List[float]): Entity of the load in the 3 directions [N].
     """
 
-    active: List[bool] = field(default_factory=lambda: [True, True, True])
-    value: List[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
+    active: List[bool]
+    value: List[float]
 
 
 @dataclass
@@ -37,8 +37,8 @@ class LineLoad(LoadParametersABC):
         - active (List[bool]): Activate/deactivate load for each direction.
         - value (List[float]): Entity of the load in the 3 directions [N].
     """
-    active: List[bool] = field(default_factory=lambda: [True, True, True])
-    value: List[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
+    active: List[bool]
+    value: List[float]
 
 
 @dataclass
@@ -50,8 +50,8 @@ class SurfaceLoad(LoadParametersABC):
         - active (List[bool]): Activate/deactivate load for each direction.
         - value (List[float]): Entity of the load in the 3 directions [N].
     """
-    active: List[bool] = field(default_factory=lambda: [True, True, True])
-    value: List[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
+    active: List[bool]
+    value: List[float]
 
 
 @dataclass
@@ -72,10 +72,10 @@ class MovingLoad(LoadParametersABC):
         - offset (float): Offset of the moving load [m].
     """
 
-    load: Union[List[float], List[str]] = field(default_factory=lambda: [0.0, 0.0, 0.0])
-    direction: List[float] = field(default_factory=lambda: [1, 1, 1])
-    velocity: Union[float, str] = 0.0
-    origin: List[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
+    load: Union[List[float], List[str]]
+    direction: List[float]
+    velocity: Union[float, str]
+    origin: List[float]
     offset: float = 0.0
 
 
@@ -92,5 +92,5 @@ class GravityLoad(LoadParametersABC):
         - value (List[float]): Entity of the gravity acceleration in the 3 directions [m/s^2]. Should be -9.81 only in
             the vertical direction
     """
-    active: List[bool] = field(default_factory=lambda: [False, False, False])
-    value: List[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
+    active: List[bool]
+    value: List[float]

--- a/stem/utils.py
+++ b/stem/utils.py
@@ -1,0 +1,47 @@
+from typing import Sequence
+
+import numpy as np
+
+
+def is_collinear(point:Sequence, start_point:Sequence, end_point:Sequence):
+    """
+    Check if point is aligned with the other two on a line. Points must have the same dimension (2D or 3D)
+
+    Args:
+        point (Sequence): point to be tested
+        start_point (Sequence): first point on the line
+        end_point (Sequence): second point on the line
+
+    Returns:
+        bool: whether the point is aligned or not
+    """
+
+    vec_1 = np.asarray(point) - np.asarray(start_point)
+    vec_2 = np.asarray(end_point) - np.asarray(start_point)
+
+    cross_product = np.cross(vec_1, vec_2)
+    return np.sum(np.abs(cross_product)) < 1e-06
+
+
+def is_point_between_points(point, start_point, end_point):
+    """
+    Check if point is between the other two. Points must have the same dimension (2D or 3D).
+
+    Args:
+        point (Sequence): point to be tested
+        start_point (Sequence): first extreme on the line
+        end_point (Sequence): second extreme on the line
+
+    Returns:
+        bool: whether the point is between the other two or not
+    """
+
+    # Calculate vectors between the points
+    vec_1 = np.asarray(point) - np.asarray(start_point)
+    vec_2 = np.asarray(end_point) - np.asarray(start_point)
+
+    # Calculate the scalar projections of vector1 onto vector2
+    scalar_projection = sum(v1 * v2 for v1, v2 in zip(vec_1, vec_2)) / sum(v ** 2 for v in vec_2)
+
+    # Check if the scalar projection is between 0 and 1 (inclusive)
+    return 0 <= scalar_projection <= 1

--- a/tests/test_kratos_loads_io.py
+++ b/tests/test_kratos_loads_io.py
@@ -38,7 +38,7 @@ class TestKratosLoadsIO:
 
         # collect the part names and parameters into a dictionary
         # TODO: change later when model part is implemented
-        all_boundary_parameters = {
+        all_load_parameters = {
             "test_point_load": point_load_parameters,
             "test_line_load": line_load_parameters,
             "test_surface_load": surface_load_parameters,
@@ -56,7 +56,7 @@ class TestKratosLoadsIO:
         # TODO: when model part are implemented, generate file through kratos_io
         boundaries_io = KratosLoadsIO(domain="PorousDomain")
 
-        for part_name, part_parameters in all_boundary_parameters.items():
+        for part_name, part_parameters in all_load_parameters.items():
             _parameters = boundaries_io.create_load_dict(
                 part_name=part_name, parameters=part_parameters
             )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,49 @@
+
+from stem.utils import *
+
+
+class TestUtilsStem:
+
+    def test_collinearity_2d(self):
+
+        p1 = np.array([0, 0])
+        p2 = np.array([-2, -1])
+
+        p_test_1 = np.array([2, 1])
+        p_test_2 = np.array([-5, 1])
+
+        assert is_collinear(point=p_test_1, start_point=p1, end_point=p2)
+        assert not is_collinear(point=p_test_2, start_point=p1, end_point=p2)
+
+    def test_collinearity_3d(self):
+
+        p1 = np.array([0, 0, 0])
+        p2 = np.array([-2, -2, 2])
+
+        p_test_1 = np.array([2, 2, -2])
+        p_test_2 = np.array([2, -2, 2])
+
+        assert is_collinear(point=p_test_1, start_point=p1, end_point=p2)
+        assert not is_collinear(point=p_test_2, start_point=p1, end_point=p2)
+
+    def test_is_in_between_2d(self):
+
+        p1 = np.array([0, 0])
+        p2 = np.array([-2, -2])
+
+        p_test_1 = np.array([2, 2])
+        p_test_2 = np.array([-1, -1])
+
+        assert not is_point_between_points(point=p_test_1, start_point=p1, end_point=p2)
+        assert is_point_between_points(point=p_test_2, start_point=p1, end_point=p2)
+
+    def test_is_in_between_3d(self):
+
+        p1 = np.array([0, 0, 0])
+        p2 = np.array([-2, -2, 2])
+
+        p_test_1 = np.array([2, 2, -2])
+        p_test_2 = np.array([-1, -1, 1])
+
+        assert not is_point_between_points(point=p_test_1, start_point=p1, end_point=p2)
+        assert is_point_between_points(point=p_test_2, start_point=p1, end_point=p2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,9 @@ import pprint
 from typing import Dict, Any
 
 import numpy.testing as npt
+import pytest
+
+from stem.geometry import Geometry
 
 
 class TestUtils:
@@ -37,3 +40,37 @@ class TestUtils:
 
             else:
                 npt.assert_allclose(v, actual[k])
+
+    @staticmethod
+    def assert_almost_equal_geometries(expected_geometry: Geometry, actual_geometry:Geometry):
+        """
+        Checks whether two Geometries are (almost) equal.
+
+        Args:
+            expected_geometry (:class:`stem.geometry.Geometry`): expected geometry of the model
+            actual_geometry (:class:`stem.geometry.Geometry`): actual geometry of the model
+
+        Returns:
+
+        """
+        # check if points are added correctly
+        for generated_point, expected_point in zip(actual_geometry.points, expected_geometry.points):
+            if generated_point.id != expected_point.id:
+                a=1+1
+            assert generated_point.id == expected_point.id
+            assert pytest.approx(generated_point.coordinates) == expected_point.coordinates
+
+        # check if lines are added correctly
+        for generated_line, expected_line in zip(actual_geometry.lines, expected_geometry.lines):
+            assert generated_line.id == expected_line.id
+            assert generated_line.point_ids == expected_line.point_ids
+
+        # check if surfaces are added correctly
+        for generated_surface, expected_surface in zip(actual_geometry.surfaces, expected_geometry.surfaces):
+            assert generated_surface.id == expected_surface.id
+            assert generated_surface.line_ids == expected_surface.line_ids
+
+        # check if volumes are added correctly
+        for generated_volume, expected_volume in zip(actual_geometry.volumes, expected_geometry.volumes):
+            assert generated_volume.id == expected_volume.id
+            assert generated_volume.surface_ids == expected_volume.surface_ids


### PR DESCRIPTION
- Fixing errors when test_model fails and gmsh keeps running (not closed when a test fails because the destroyer method is not called).  
- Added geometry generation for point, line, surface and moving point loads.  
- Tested geometry for point, line and moving point loads. Still missing for surface loads.  
- Removing defaults from the load parameters.  
- Minor fixes of variable names