### PR TITLE
fixed bug in node ordering condition elements

### DIFF
--- a/stem/model.py
+++ b/stem/model.py
@@ -1007,7 +1007,7 @@ class Model:
             raise ValueError(f"Mesh of process model part: {process_model_part.name} is not yet initialised.")
 
         # loop over the matched elements
-        flip_node_order = np.zeros(len(matched_elements), dtype=bool)
+        flip_node_order: Dict[int, bool] = {}
 
         for i, (process_element, body_element) in enumerate(matched_elements.items()):
 
@@ -1017,24 +1017,31 @@ class Model:
 
             if process_el_info["ndim"] == 1:
 
+                # initialise flip node order to False
+                flip_node_order[process_element.id] = False
+
                 # get all line edges of the body element and check if the process element is defined on one of them
                 # if the nodes are equal, but the node order isn't, flip the node order of the process element
                 body_line_edges = Utils.get_element_edges(body_element)
                 for edge in body_line_edges:
                     if set(edge) == set(process_element.node_ids):
                         if list(edge) != process_element.node_ids:
-                            flip_node_order[i] = True
+                            flip_node_order[process_element.id] = True
 
             elif body_el_info["ndim"] == 3 and process_el_info["ndim"] == 2:
 
                 # check if the normal of the condition element is defined outwards of the body element
-                flip_node_order[i] = Utils.is_volume_edge_defined_outwards(process_element, body_element,
-                                                                           self.gmsh_io.mesh_data["nodes"])
+                flip_node_order[process_element.id] = Utils.is_volume_edge_defined_outwards(process_element,
+                                                                                            body_element,
+                                                                                            self.gmsh_io.mesh_data[
+                                                                                                "nodes"])
 
         # flip condition elements if required
-        if any(flip_node_order):
-            # elements to be flipped
-            elements = np.array(list(process_model_part.mesh.elements.values()))[flip_node_order]
+        if any(list(flip_node_order.values())):
+
+            # get the elements to be flipped
+            elements = [process_model_part.mesh.elements[el_id] for el_id in flip_node_order.keys() if
+                        flip_node_order[el_id]]
 
             # flip elements, it is required that all elements in the array are of the same type
             Utils.flip_node_order(elements)

--- a/stem/utils.py
+++ b/stem/utils.py
@@ -284,7 +284,7 @@ class Utils:
 
     @staticmethod
     def is_volume_edge_defined_outwards(edge_element: 'Element', body_element: 'Element',
-                                        nodes: Dict[int, Sequence[float]]) -> Optional[bool]:
+                                        nodes: Dict[int, Sequence[float]]) -> bool:
         """
         Checks if the normal vector of the edge element is pointing outwards of the body element.
 
@@ -299,7 +299,7 @@ class Utils:
             - ValueError: when not all nodes of the edge element are part of the body element.
 
         Returns:
-            - Optional[bool]: True if the normal vector of the edge element is pointing outwards of the body element,
+            - bool: True if the normal vector of the edge element is pointing outwards of the body element,
                 False otherwise.
 
         """

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2405,6 +2405,62 @@ class TestModel:
         # check if the node ids of the process model part are in the correct order
         assert process_model_part.mesh.elements[1].node_ids == [1, 2]
 
+    def test_check_ordering_process_model_part_2d_multiple_elements(self):
+        """
+        Test if the node order of the first element in process model part is flipped in a 2D case. The second element
+        should not be flipped. This test check for any order of the process element to body element mapping.
+
+        """
+
+        # create model
+        model = Model(2)
+
+        # manually set mesh data nodes
+        model.gmsh_io._GmshIO__mesh_data = {"nodes": {1: [0, 0, 0], 2: [1, 0, 0], 3: [1, 1, 0], 4: [0, 1, 0]}}
+
+        # manually create process model part with nodes in reverse order
+        process_element1 = Element(1, "LINE_2N", [2, 1])
+        process_element2 = Element(2, "LINE_2N", [2, 3])
+        process_model_part = ModelPart("process")
+        process_mesh = Mesh(1)
+        process_mesh.elements = {1: process_element1,
+                                 2: process_element2}
+        process_mesh.nodes = {1: Node(1, [0, 0, 0]), 2: Node(2, [1, 0, 0]), 3: Node(3, [1, 1, 0])}
+        process_model_part.mesh = process_mesh
+        model.process_model_parts = [ModelPart("process")]
+
+        # create body_model_part
+        body_element = Element(2, "TRIANGLE_3N", [1, 2, 3])
+
+        # check ordering of process model part connectivities
+        mapper = {process_element1: body_element,
+                  process_element2: body_element}
+        model._Model__check_ordering_process_model_part(mapper, process_model_part)
+
+        # check if the node ids of the process model part are in the correct order, i.e. the node order of only the
+        # first element should be flipped
+        assert process_model_part.mesh.elements[1].node_ids == [1, 2]
+        assert process_model_part.mesh.elements[2].node_ids == [2, 3]
+
+        # redefine process elements and redefine mapper in reverse order
+        # manually create process model part with nodes in outwards normal order
+        process_element1 = Element(1, "LINE_2N", [2, 1])
+        process_element2 = Element(2, "LINE_2N", [2, 3])
+        process_mesh.elements = {1: process_element1,
+                                 2: process_element2}
+
+        # add process_element and body_element to mapper
+        mapper = {process_element2: body_element,
+                  process_element1: body_element}
+
+        # check ordering of process model part connectivities
+        model._Model__check_ordering_process_model_part(mapper, process_model_part)
+
+        # check if the node ids of the process model part are in the correct order, i.e. the node order of only the
+        # first element should be flipped (the same order as before)
+        assert process_model_part.mesh.elements[1].node_ids == [1, 2]
+        assert process_model_part.mesh.elements[2].node_ids == [2, 3]
+
     def test_check_ordering_process_model_part_3d(self):
         """
         Test if the node order of the process model part is flipped, such that the normal is inwards. After filling in


### PR DESCRIPTION
conditions were stored in an unsorted dictionary and later sorted based on a sorted list. As a result, wrong conditions were sorted