### PR TITLE
Fix: wrong definition of model part when None is given to the Output class

### DIFF
--- a/stem/output.py
+++ b/stem/output.py
@@ -372,12 +372,12 @@ class Output:
         # if the output parameters are JSON or GiD, set the output name
         elif isinstance(output_parameters, JsonOutputParameters):
             if part_name is None:
-                part_name = "output_full_model"
+                part_name = "porous_computational_model_part"
             if output_name is None or output_name == "":
                 output_name = f"{part_name}.json"
         elif isinstance(output_parameters, GiDOutputParameters):
             if part_name is None:
-                part_name = "output_full_model"
+                part_name = "porous_computational_model_part"
             if output_name is None or output_name == "":
                 output_name = f"{part_name}"
 

--- a/tests/test_data/expected_output_parameters.json
+++ b/tests/test_data/expected_output_parameters.json
@@ -83,6 +83,37 @@
                     "point_data_configuration":  []
                 }
             }
+        }, 
+        {
+            "Parameters": {
+                "model_part_name": "PorousDomain.porous_computational_model_part",
+                "output_name": "test_gid1",
+                "postprocess_parameters": {
+                    "point_data_configuration": [],
+                    "result_file_configuration": {
+                        "file_label": "step",
+                        "gauss_point_results": [
+                            "VON_MISES_STRESS",
+                            "FLUID_FLUX_VECTOR",
+                            "HYDRAULIC_HEAD"
+                        ],
+                        "gidpost_flags": {
+                            "GiDPostMode": "GiD_PostBinary",
+                            "MultiFileFlag": "SingleFile",
+                            "WriteConditionsFlag": "WriteElementsOnly",
+                            "WriteDeformedMeshFlag": "WriteUndeformed"},
+                        "nodal_results": [
+                            "DISPLACEMENT",
+                            "TOTAL_DISPLACEMENT"
+                        ],
+                        "output_control_type": "step",
+                        "output_interval": 100
+                    }
+                }
+            },
+            "kratos_module": "KratosMultiphysics",
+            "process_name": "GiDOutputProcess",
+            "python_module": "gid_output_process"
         }],
         "vtk_output": [{
             "python_module": "vtk_output_process",
@@ -120,7 +151,28 @@
                     "GREEN_LAGRANGE_STRAIN_VECTOR"
                 ]
             }
-        }]
+        }, 
+        {
+            "Parameters": 
+            {"file_format": "binary",
+                "gauss_point_variables_in_elements": [
+                    "VON_MISES_STRESS",
+                    "FLUID_FLUX_VECTOR",
+                    "HYDRAULIC_HEAD"
+                ],
+                "model_part_name": "PorousDomain",
+                "nodal_solution_step_data_variables": [
+                    "DISPLACEMENT",
+                    "TOTAL_DISPLACEMENT"
+                ],
+                "output_control_type": "step",
+                "output_interval": 100.0,
+                "output_path": "output_vtk_full_model",
+                "output_precision": 8},
+            "kratos_module": "KratosMultiphysics",
+            "process_name": "VtkOutputProcess", 
+            "python_module": "vtk_output_process"}
+        ]
     },
     "processes": {
         "json_output": [{
@@ -162,6 +214,23 @@
                 ],
                 "time_frequency": 0.002
             }
-        }]
+        },
+        {
+            "kratos_module": "KratosMultiphysics",
+            "process_name": "JsonOutputProcess",
+            "python_module": "json_output_process",
+            "Parameters": {
+                "gauss_points_output_variables": [
+                    "VON_MISES_STRESS",
+                    "FLUID_FLUX_VECTOR",
+                    "HYDRAULIC_HEAD"],
+                "model_part_name": "PorousDomain.porous_computational_model_part",
+                "output_file_name": "test_json_output1.json",
+                "output_variables": [
+                    "DISPLACEMENT",
+                    "TOTAL_DISPLACEMENT"
+                ],
+                "time_frequency": 0.002}}
+        ]
     }
 }

--- a/tests/test_kratos_outputs_io.py
+++ b/tests/test_kratos_outputs_io.py
@@ -236,9 +236,27 @@ class TestKratosOutputsIO:
             output_dir="dir_test",
             output_parameters=json_output_parameters2,
         )
+
+        # create output objects with None part specified
+        gid_output_process_none_part = Output(
+            part_name=None,
+            output_name=r"test_gid1",
+            output_parameters=gid_output_parameters1,
+        )
+        vtk_output_process_none_part = Output(
+            part_name=None,
+            output_parameters=vtk_output_parameters1,
+        )
+        json_output_process_none_part = Output(
+            part_name=None,
+            output_name="test_json_output1",
+            output_parameters=json_output_parameters1,
+        )
+
         all_outputs = [
             gid_output_process1, vtk_output_process1, json_output_process1, gid_output_process2, vtk_output_process2,
-            json_output_process2, gid_output_process3
+            json_output_process2, gid_output_process3, gid_output_process_none_part, vtk_output_process_none_part,
+            json_output_process_none_part
         ]
 
         # write dictionary for the output(s)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -791,7 +791,7 @@ class TestUtilsStem:
         with pytest.raises(ValueError,
                            match=f"Coordinates should be a sequence of sequence of real numbers, "
                            f"but nan was given."):
-            Utils.validate_coordinates([(0.0, 0.0, 0.0), (0.0, np.NAN, 0.0)])
+            Utils.validate_coordinates([(0.0, 0.0, 0.0), (0.0, np.nan, 0.0)])
 
         # test for inf numbers
         with pytest.raises(ValueError,


### PR DESCRIPTION
Fix: wrong definition of model part when None is given to the Output class for the `part_name` input.

- added tests for when None is given
- the generated parameters have been checked with Kratos (not crashing anymore) and when possible visually (paraview or Json).

Resolves #220