### PR TITLE
Adjust desired time step in json by subtracting the time precision

### DIFF
--- a/benchmark_tests/test_1d_wave_prop_drained_soil/test_1d_wave_prop_drained_soil.py
+++ b/benchmark_tests/test_1d_wave_prop_drained_soil/test_1d_wave_prop_drained_soil.py
@@ -116,7 +116,7 @@ def test_stem():
                               output_name="vtk_output")
 
     model.add_output_settings_by_coordinates([[0, 5, 0], [1, 5, 0]],
-                                             JsonOutputParameters(output_interval=delta_time * 0.99,
+                                             JsonOutputParameters(output_interval=delta_time,
                                                                   nodal_results=nodal_results,
                                                                   gauss_point_results=[]),
                                              "calculated_output",

--- a/benchmark_tests/test_beam_multistage/test_beam_multistage.py
+++ b/benchmark_tests/test_beam_multistage/test_beam_multistage.py
@@ -104,7 +104,7 @@ def test_stem():
     model.project_parameters = problem
 
     # Define the output process
-    json_output = JsonOutputParameters(0.049, nodal_results=[NodalOutput.DISPLACEMENT_Y])
+    json_output = JsonOutputParameters(0.05, nodal_results=[NodalOutput.DISPLACEMENT_Y])
     model.add_output_settings(json_output, "moving_load")
 
     input_folder = r"benchmark_tests/test_beam_multistage/input_kratos"

--- a/benchmark_tests/test_mass_on_spring_damper/test_mass_on_spring_damper.py
+++ b/benchmark_tests/test_mass_on_spring_damper/test_mass_on_spring_damper.py
@@ -114,7 +114,7 @@ def test_stem():
     model.add_output_settings(output_dir=".",
                               part_name="mass",
                               output_name="output_mass",
-                              output_parameters=JsonOutputParameters(output_interval=delta_time * 0.99,
+                              output_parameters=JsonOutputParameters(output_interval=delta_time,
                                                                      nodal_results=nodal_results,
                                                                      gauss_point_results=gauss_point_results))
 

--- a/benchmark_tests/test_multi_stage_dynamic_to_static/test_multistage_dynamic_to_static.py
+++ b/benchmark_tests/test_multi_stage_dynamic_to_static/test_multistage_dynamic_to_static.py
@@ -139,7 +139,7 @@ def test_stem():
         coordinates=output_coordinates,
         part_name="midline_output",
         output_parameters=JsonOutputParameters(
-            output_interval=delta_time - 1e-8,
+            output_interval=delta_time,
             nodal_results=nodal_results,
             gauss_point_results=[],
         ),

--- a/benchmark_tests/test_multi_stage_umat/test_multi_stage_umat.py
+++ b/benchmark_tests/test_multi_stage_umat/test_multi_stage_umat.py
@@ -139,8 +139,7 @@ def test_stem():
 
     model_stage_1.add_output_settings_by_coordinates(coordinates=output_coordinates,
                                                      part_name="midline_output",
-                                                     output_parameters=JsonOutputParameters(output_interval=delta_time -
-                                                                                            1e-8,
+                                                     output_parameters=JsonOutputParameters(output_interval=delta_time,
                                                                                             nodal_results=nodal_results,
                                                                                             gauss_point_results=[]),
                                                      output_dir="output",

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -1104,8 +1104,7 @@ type is set to "step", meaning that the results will be written every time step.
 Additionally, nodal output can be retrieved on given coordinates, however it is required that these coordinates are
 placed on an existing surface within the model. For this tutorial, output is given on a few points perpendicular to
 the track. The results will be stored in a json file in the output folder. For json output it is required that the
-output interval is defined in seconds. In order to output data at each time step, a slightly smaller time interval than
-the calculation time step `delta_time` is required.
+output interval is defined in seconds.
 
 .. code-block:: python
 
@@ -1121,7 +1120,7 @@ the calculation time step `delta_time` is required.
         output_name="json_output",
         coordinates=desired_output_points,
         output_parameters=JsonOutputParameters(
-            output_interval=delta_time-1e-10,
+            output_interval=delta_time,
             nodal_results=nodal_results,
             gauss_point_results=gauss_point_results
         )

--- a/stem/globals.py
+++ b/stem/globals.py
@@ -7,6 +7,9 @@ from typing import Dict, Any
 GRAVITY_VALUE = -9.81  # [m/s2]
 VERTICAL_AXIS = 1  # [0, 1, 2] = [x, y, z]
 OUT_OF_PLANE_AXIS_2D = 2  # [0, 1, 2] = [x, y, z]
+# time step to subtract to the actual desired time step
+# Kratos provides the first time step following the desired one
+TIME_STEP_PRECISION = 1e-08  # s
 
 # yapf: disable
 #: Element data for supported element types in STEM. The data contains the following information: \

--- a/tests/test_data/expected_output_parameters.json
+++ b/tests/test_data/expected_output_parameters.json
@@ -191,7 +191,7 @@
                     "FLUID_FLUX_VECTOR",
                     "HYDRAULIC_HEAD"
                 ],
-                "time_frequency": 0.002
+                "time_frequency":  0.00199999
             }
         },
         {
@@ -212,7 +212,7 @@
                     "TOTAL_STRESS_TENSOR",
                     "GREEN_LAGRANGE_STRAIN_VECTOR"
                 ],
-                "time_frequency": 0.002
+                "time_frequency":  0.00199999
             }
         },
         {
@@ -230,7 +230,7 @@
                     "DISPLACEMENT",
                     "TOTAL_DISPLACEMENT"
                 ],
-                "time_frequency": 0.002}}
+                "time_frequency":  0.00199999}}
         ]
     }
 }

--- a/tests/test_stem.py
+++ b/tests/test_stem.py
@@ -1098,7 +1098,7 @@ class TestStem:
                                                  part_name="nodal_accelerations",
                                                  output_name="json_nodal_accelerations",
                                                  output_dir="output",
-                                                 output_parameters=JsonOutputParameters(output_interval=0.0025 - 1e-10,
+                                                 output_parameters=JsonOutputParameters(output_interval=0.0025,
                                                                                         nodal_results=nodal_results))
 
         # define the STEM instance


### PR DESCRIPTION
Subtract the time precision to request output frequency. Kratos provides the first time step right after the request time stamp so if 0.2000 is requested and the time step is 0.02, a time-step of 0.202 is given instead.
To avoid this the time-precision (1e-08) is subtracted to the requested time step so that by requesting a time-step of 0.1999999 the correct time step of 0.2 is provided in output.

Tests and checks:
- tutorials (removed recommendation to subtract yourself the precision)
- benchmarks (remove subtraction of precision, check same result is returned)
- tests (adjust desired output json file for timestamps)

Solves #255 .